### PR TITLE
Molecule: Specify container registry

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,10 +10,10 @@ lint:
     config-file: molecule/default/yamllint.yml
 platforms:
   - name: centos-6
-    image: linuxsystemroles/centos-6
+    image: docker.io/linuxsystemroles/centos-6
     privileged: true
   - name: centos-7
-    image: linuxsystemroles/centos-7
+    image: docker.io/linuxsystemroles/centos-7
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true


### PR DESCRIPTION
To avoid name squatting attacks/problems it is necessary to specify the
container registry when specifying a container image. Otherwise an image
with the same name from a different registry could be obtained.

References: https://raesene.github.io/blog/2019/09/25/typosquatting-in-a-multi-registry-world/