### PR TITLE
Return back Jinja vars in task names.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     enabled: yes
   loop: "{{ __template_services }}"
 
-- name: Generate a configuration for foo
+- name: Generate /etc/{{ __template_foo_config }}
   template:
     src: "{{ __template_foo_config }}.j2"
     dest: /etc/{{ __template_foo_config }}


### PR DESCRIPTION
As Jinja variables are expanded properly in task names, we are returning them back (this makes Ansible logs more readable).