### PR TITLE
ensure module_utils imports can be resolved

### DIFF
--- a/tests/setup_module_utils.sh
+++ b/tests/setup_module_utils.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ -n "${DEBUG:-}" ] ; then
+    set -x
+fi
+
+if [ ! -d "${1:-}" -o ! -d "${2:-}" ] ; then
+    exit 0
+fi
+
+# we need absolute path for $2
+absmoddir=$( readlink -f "$2" )
+
+# clean up old links to module_utils
+for item in "$1"/* ; do
+    if lnitem=$( readlink "$item" ) && test -n "$lnitem" ; then
+        case "$lnitem" in
+            *"${2}"*) rm -f "$item" ;;
+        esac
+    fi
+done
+
+# add new links to module_utils
+for item in "$absmoddir"/* ; do
+    case "$item" in
+        *__pycache__) continue;;
+        *.pyc) continue;;
+    esac
+    bnitem=$( basename "$item" )
+    ln -s "$item" "$1/$bnitem"
+done

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,17 @@ skip_missing_interpreters = true
 [testenv]
 basepython = python3
 # List common dependencies for Python interpreters here:
+# note that we dropped support for ansible 2.6, and ansible
+# 2.7 dropped support for py26 - so we only do ansible
+# related testing on py27 and later
 deps =
+    py{27,36,37,38}: ansible
     py{26,27,36,37,38}: pytest-cov
     py{27,36,37,38}: pytest>=3.5.1
     py{26,27}: mock
     py26: pytest
+commands_pre =
+    bash {toxinidir}/tests/setup_module_utils.sh {envsitepackagesdir}/ansible/module_utils {toxinidir}/module_utils
 
 [base]
 system_python = /usr/bin/python3
@@ -141,9 +147,10 @@ passenv = RUN_PYLINT_*
 setenv =
     {[base]setenv}
 deps =
+    ansible
     colorama
     pylint>=1.8.4
-    ansible
+    pytest
     -rpylint_extra_requirements.txt
 whitelist_externals =
     {[base]whitelist_externals}


### PR DESCRIPTION
When running pytest, pylint, etc. in tox, ensure that
imports like

    import ansible.module_utils.mylocalutils

can be resolved correctly.  We rely on the fact that the
`tox` `testenv` `commands_pre` commands are run for every
test, before the actual test command.  The `commands_pre`
will run the script `tests/setup_module_utils.sh`.  This
script will see if the role has installed `ansible` in
the current tox venv, and that the role has local
`module_utils/`.  If so, the script will link the local
`module_utils/` files and directories inside the tox
venv `ansible/module_utils` so that the imports will be
found in the default pythonpath.

However
- this will not work outside of a venv, tox or otherwise,
unless you don't mind altering the system ansible install
- if there is already a `commands_pre` for a tox env, that
tox env will need to add `{[testenv]commands_pre}` before
any other commands listed.