### PR TITLE
improvements to let projects override defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ vault.yml
 /tests/.coverage
 /tests/htmlcov*
 /.tox
+/venv*/
+/.venv/
+.vscode/
+artifacts/
+__pycache__/
+*~
+.pytest_cache/

--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -16,6 +16,7 @@
 #
 #       - LSR_PUBLISH_COVERAGE
 #       - LSR_TESTSDIR
+#       - function lsr_runcoveralls_hook
 #
 # Environment variables that not start with LSR_* but have influence on CI
 # process:
@@ -31,8 +32,13 @@
 #       - RUN_BLACK_INCLUDE
 #       - RUN_BLACK_EXCLUDE
 #       - RUN_BLACK_DISABLED
+#       - RUN_BLACK_EXTRA_ARGS
 #
 #   * .travis/runflake8.sh:
 #
 #       - RUN_FLAKE8_DISABLED
+#       - RUN_FLAKE8_IGNORE
 #
+#   * .travis/runsyspycmd.sh:
+#
+#       - function lsr_runsyspycmd_hook

--- a/.travis/custom.sh
+++ b/.travis/custom.sh
@@ -11,7 +11,6 @@ set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
-TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh

--- a/.travis/runblack.sh
+++ b/.travis/runblack.sh
@@ -20,6 +20,9 @@
 #
 #   RUN_BLACK_DISABLED
 #     if set to an arbitrary non-empty value, black will be not executed
+#
+#   RUN_BLACK_EXTRA_ARGS
+#     extra cmd line args to pass to black
 
 set -e
 
@@ -67,4 +70,5 @@ set -x
 ${ENVPYTHON} -m black \
   --include "${INCLUDE_ARG:-${RUN_BLACK_INCLUDE:-${DEFAULT_INCLUDE}}}" \
   --exclude "${EXCLUDE_ARG:-${RUN_BLACK_EXCLUDE:-${DEFAULT_EXCLUDE}}}" \
+  ${RUN_BLACK_EXTRA_ARGS:-} \
   "${OTHER_ARGS[@]}"

--- a/.travis/runcoveralls.sh
+++ b/.travis/runcoveralls.sh
@@ -27,7 +27,6 @@ set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
-TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh

--- a/.travis/runflake8.sh
+++ b/.travis/runflake8.sh
@@ -11,6 +11,8 @@
 #
 #   RUN_FLAKE8_DISABLED
 #     if set to an arbitrary non-empty value, flake8 will be not executed
+#   RUN_FLAKE8_IGNORE
+#     list of issues to ignore - see flake8 docs
 
 set -e
 
@@ -31,4 +33,6 @@ ENVPYTHON=$(readlink -f $1)
 shift
 
 set -x
-${ENVPYTHON} -m flake8 "$@"
+${ENVPYTHON} -m flake8 \
+  ${RUN_FLAKE8_IGNORE:+--ignore} ${RUN_FLAKE8_IGNORE:-} \
+  "$@"

--- a/.travis/runpylint.sh
+++ b/.travis/runpylint.sh
@@ -18,6 +18,7 @@ set -e
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
 
+. ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
 
 # Sanitize path in case if running within tox (see

--- a/.travis/runpytest.sh
+++ b/.travis/runpytest.sh
@@ -15,9 +15,9 @@ set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
-TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 
 . ${SCRIPTDIR}/utils.sh
+. ${SCRIPTDIR}/config.sh
 
 if [[ ! -d ${TOPDIR}/tests/unit ]]; then
   lsr_info "${ME}: No unit tests found. Skipping."

--- a/.travis/runsyspycmd.sh
+++ b/.travis/runsyspycmd.sh
@@ -14,7 +14,6 @@ set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
-TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
 
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -147,3 +147,8 @@ function lsr_compare_pythons() {
 function lsr_venv_python_matches_system_python() {
   lsr_compare_pythons ${1:-python} -eq ${2:-/usr/bin/python3}
 }
+
+# set TOPDIR
+ME=${ME:-$(basename $0)}
+SCRIPTDIR=${SCRIPTDIR:-$(readlink -f $(dirname $0))}
+TOPDIR=$(readlink -f ${SCRIPTDIR}/..)

--- a/.yamllint_custom.yml
+++ b/.yamllint_custom.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+---
+extends: .yamllint.yml
+# possible customizations over the base yamllint config
+# skip the yaml files in the /tests/ directory
+# NOTE: If you want to customize `ignore` you'll have to
+# copy in all of the config from .yamllint.yml, then
+# add your own - so if you want to just add /tests/ to
+# be ignored, you'll have to add the ignores from the base
+# ignore: |
+#   /tests/
+#   /.tox/
+# skip checking line length
+# NOTE: the above does not apply to `rules` - you do not
+# have to copy all of the rules from the base config
+# rules:
+#   line-length: disable

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint:
   name: yamllint
   options:
-    config-file: .yamllint.yml
+    config-file: .yamllint_custom.yml
 platforms:
   - name: centos-6
     image: docker.io/linuxsystemroles/centos-6

--- a/tox.ini
+++ b/tox.ini
@@ -166,11 +166,13 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/runflake8.sh {envpython} --statistics {posargs} .
+    bash {toxinidir}/.travis/runflake8.sh {envpython} --exclude=.venv,.tox --statistics {posargs} .
 
 [testenv:yamllint]
 deps = yamllint
-commands = yamllint .
+whitelist_externals =
+    {[base]whitelist_externals}
+commands = yamllint -c .yamllint_custom.yml .
 
 [testenv:coveralls]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:coveralls}


### PR DESCRIPTION
Make sure projects can use `.travis/config.sh` to override
settings in the CI scripts.
Have `$TOPDIR` set in `.travis/utils.sh` so that all scripts
and `.travis/config.sh` can use it.
Add some customizations for black and flake8.
Add more items to `.gitignore`
Make flake8 exclude `.tox` and `.venv`