### PR TITLE
molecule/tox: Support yamllint without molecule

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
+ignore: |
+  /.tox/
 extends: default
 rules:
   braces:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint:
   name: yamllint
   options:
-    config-file: molecule/default/yamllint.yml
+    config-file: .yamllint.yml
 platforms:
   - name: centos-6
     image: docker.io/linuxsystemroles/centos-6

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 [tox]
 envlist =
-    black, pylint, flake8,
+    black, pylint, flake8, yamllint
     py{26,27,36,37,38},
     custom
 skipsdist = true
@@ -168,6 +168,10 @@ whitelist_externals =
 commands =
     bash {toxinidir}/.travis/runflake8.sh {envpython} --statistics {posargs} .
 
+[testenv:yamllint]
+deps = yamllint
+commands = yamllint .
+
 [testenv:coveralls]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:coveralls}
 passenv = TRAVIS TRAVIS_*
@@ -272,6 +276,6 @@ python =
   2.6: py26,custom
   2.7: py27,coveralls,flake8,pylint,custom
   3.5: custom
-  3.6: py36,coveralls,black,custom
+  3.6: py36,coveralls,black,yamllint,custom
   3.7: py37,custom
   3.8: py38,custom


### PR DESCRIPTION
With molecule v3, the linter config needs to be changed. To prepare for
this, run yamllint with tox as molecule would do it for V3.

Note: extracted from https://github.com/linux-system-roles/network/pull/170