### PR TITLE
do not use envpython

### DIFF
--- a/.travis/custom.sh
+++ b/.travis/custom.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 
-# This script is executed with two arguments passed to it:
-#
-#   $1 - path to environment python (python used inside virtual environment
-#        created by tox)
-#   $2 - path to system python (python 3.x installed on the system)
-
 set -e
 
 ME=$(basename $0)
@@ -14,10 +8,5 @@ SCRIPTDIR=$(readlink -f $(dirname $0))
 
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
-
-# Sanitize arguments (see https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-SYSPYTHON=$(readlink -f $2)
-shift 2
 
 # Write your custom commands here that should be run when `tox -e custom`:

--- a/.travis/runblack.sh
+++ b/.travis/runblack.sh
@@ -5,8 +5,7 @@
 # is to get a user the opportunity to control black from config.sh via setting
 # environment variables.
 
-# The first script argument is a path to Python interpreter, the rest of
-# arguments are passed to black.
+# The given command line arguments are passed to black.
 
 # Environment variables:
 #
@@ -37,11 +36,6 @@ if [[ "${RUN_BLACK_DISABLED}" ]]; then
   exit 0
 fi
 
-# Sanitize path in case if running within tox (see
-# https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-shift
-
 DEFAULT_INCLUDE='^[^.].*\.py$'
 DEFAULT_EXCLUDE='/(\.[^.].*|tests/roles)/'
 
@@ -67,7 +61,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 set -x
-${ENVPYTHON} -m black \
+python -m black \
   --include "${INCLUDE_ARG:-${RUN_BLACK_INCLUDE:-${DEFAULT_INCLUDE}}}" \
   --exclude "${EXCLUDE_ARG:-${RUN_BLACK_EXCLUDE:-${DEFAULT_EXCLUDE}}}" \
   ${RUN_BLACK_EXTRA_ARGS:-} \

--- a/.travis/runcoveralls.sh
+++ b/.travis/runcoveralls.sh
@@ -5,8 +5,7 @@
 # provide a unified way to reporting coverage results across all linux system
 # roles projects.
 
-# The first script argument is a path to Python interpreter, the rest of
-# arguments are passed to coveralls.
+# The given command line arguments are passed to coveralls.
 
 # Environment variables:
 #
@@ -38,11 +37,6 @@ if [[ -z "${LSR_PUBLISH_COVERAGE}" ]]; then
 fi
 
 LSR_TESTSDIR=${LSR_TESTSDIR:-${TOPDIR}/tests}
-
-# Sanitize path in case if running within tox (see
-# https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-shift
 
 COVERALLSCMD=$(command -v coveralls)
 
@@ -85,7 +79,7 @@ EOF
 # Rename $COVERAGEFILE to ${COVERAGEFILE}.merge. With this trick, coverage
 # combine applies configuration in $COVERAGERCFILE also to $COVERAGEFILE.
 mv ${COVERAGEFILE} ${COVERAGEFILE}.merge
-${ENVPYTHON} -m coverage combine --append
+python -m coverage combine --append
 
 MAYBE_DEBUG=""
 if [[ "${LSR_PUBLISH_COVERAGE}" == "debug" ]]; then
@@ -93,4 +87,4 @@ if [[ "${LSR_PUBLISH_COVERAGE}" == "debug" ]]; then
 fi
 
 set -x
-${ENVPYTHON} ${COVERALLSCMD} ${MAYBE_DEBUG} "$@"
+python ${COVERALLSCMD} ${MAYBE_DEBUG} "$@"

--- a/.travis/runflake8.sh
+++ b/.travis/runflake8.sh
@@ -4,8 +4,7 @@
 # A shell wrapper around flake8. The purpose of this wrapper is to get to user
 # an opportunity to disable running flake8 via config.sh.
 
-# The first script argument is a path to Python interpreter, the rest of
-# arguments are passed to flake8.
+# The given command line arguments are passed to flake8.
 
 # Environment variables:
 #
@@ -27,12 +26,7 @@ if [[ "${RUN_FLAKE8_DISABLED}" ]]; then
   exit 0
 fi
 
-# Sanitize path in case if running within tox (see
-# https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-shift
-
 set -x
-${ENVPYTHON} -m flake8 \
+python -m flake8 \
   ${RUN_FLAKE8_IGNORE:+--ignore} ${RUN_FLAKE8_IGNORE:-} \
   "$@"

--- a/.travis/runpylint.sh
+++ b/.travis/runpylint.sh
@@ -10,8 +10,7 @@
 #       which set them by including config.sh). Now, they take effect also when
 #       running tox locally.
 
-# First argument to the script is a path to environment python, the rest of
-# arguments are passed to custom_pylint.py.
+# The given command line arguments are passed to custom_pylint.py.
 
 set -e
 
@@ -21,10 +20,5 @@ SCRIPTDIR=$(readlink -f $(dirname $0))
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
 
-# Sanitize path in case if running within tox (see
-# https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-shift
-
 set -x
-${ENVPYTHON} ${SCRIPTDIR}/custom_pylint.py "$@"
+python ${SCRIPTDIR}/custom_pylint.py "$@"

--- a/.travis/runpytest.sh
+++ b/.travis/runpytest.sh
@@ -8,8 +8,7 @@
 # running pytest if there are no unit tests and filters out --cov*/--no-cov*
 # arguments if there is nothing to be analyzed with coverage.
 
-# First argument to the script is a path to environment python, the rest of
-# arguments are passed to pytest.
+# The given command line arguments are passed to pytest.
 
 set -e
 
@@ -23,11 +22,6 @@ if [[ ! -d ${TOPDIR}/tests/unit ]]; then
   lsr_info "${ME}: No unit tests found. Skipping."
   exit 0
 fi
-
-# Sanitize path in case if running within tox (see
-# https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-shift
 
 PYTEST_OPTS=()
 PYTEST_OPTS_NOCOV=()
@@ -58,4 +52,4 @@ if [[ "${USE_COV}" == "no" ]]; then
 fi
 
 set -x
-${ENVPYTHON} -m pytest "${PYTEST_OPTS[@]}"
+python -m pytest "${PYTEST_OPTS[@]}"

--- a/.travis/runsyspycmd.sh
+++ b/.travis/runsyspycmd.sh
@@ -5,10 +5,8 @@
 # to system python libraries, especially C bindings. The script is run with
 # these arguments:
 #
-#   $1     - path to environment python
-#   $2     - path to system python
-#   $3     - command runnable in Python (should be present in $PATH)
-#   ${@:4} - arguments passed to $3
+#   $1     - command runnable in Python (should be present in $PATH)
+#   ${@:2} - arguments passed to $1
 
 set -e
 
@@ -18,12 +16,7 @@ SCRIPTDIR=$(readlink -f $(dirname $0))
 . ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
 
-# Sanitize arguments (see https://github.com/tox-dev/tox/issues/1463):
-ENVPYTHON=$(readlink -f $1)
-SYSPYTHON=$(readlink -f $2)
-shift 2
-
-if ! lsr_venv_python_matches_system_python ${ENVPYTHON} ${SYSPYTHON}; then
+if ! lsr_venv_python_matches_system_python ; then
   lsr_info "${ME}: ${1:-<missing command>}:" \
     "Environment Python has no access to system Python libraries. Skipping."
   exit 0
@@ -33,4 +26,4 @@ COMMAND=$(command -v $1)
 shift
 
 set -x
-${ENVPYTHON} ${COMMAND} "$@"
+python ${COMMAND} "$@"

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -136,19 +136,42 @@ function lsr_compare_pythons() {
 }
 
 ##
+# lsr_get_system_python
+#
+# Return the system python, or /usr/bin/python3 if nothing
+# else can be found in a standard location.
+function lsr_get_system_python() {
+  local syspython=$(command -pv python3)
+  if [[ -z "$syspython" ]]; then
+    syspython=$(command -pv python)
+  fi
+  if [[ -z "$syspython" ]]; then
+    syspython=$(command -pv python2)
+  fi
+  echo ${syspython:-/usr/bin/python3}
+}
+
+##
 # lsr_venv_python_matches_system_python [$1] [$2]
 #
 #   $1 - command or full path to venv Python interpreter (default: python)
 #   $2 - command or full path to the system Python interpreter
-#        (default: /usr/bin/python3)
+#        (default: /usr/bin/python3 or /usr/bin/python or /usr/bin/python2)
 #
 # Exit with 0 if virtual environment Python version matches the system Python
 # version.
 function lsr_venv_python_matches_system_python() {
-  lsr_compare_pythons ${1:-python} -eq ${2:-/usr/bin/python3}
+  local syspython="${2:-$(lsr_get_system_python)}"
+
+  lsr_compare_pythons ${1:-python} -eq ${syspython:-/usr/bin/python3}
 }
 
 # set TOPDIR
 ME=${ME:-$(basename $0)}
 SCRIPTDIR=${SCRIPTDIR:-$(readlink -f $(dirname $0))}
 TOPDIR=$(readlink -f ${SCRIPTDIR}/..)
+
+# Local Variables:
+# mode: Shell-script
+# sh-basic-offset: 2
+# End:

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ commands_pre =
     bash {toxinidir}/tests/setup_module_utils.sh {envsitepackagesdir}/ansible/module_utils {toxinidir}/module_utils
 
 [base]
-system_python = /usr/bin/python3
 passenv = *
 setenv =
     PYTHONPATH = {toxinidir}/library:{toxinidir}/module_utils
@@ -49,7 +48,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py26 \
@@ -67,7 +66,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py27 \
@@ -85,7 +84,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py36 \
@@ -103,7 +102,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py37 \
@@ -121,7 +120,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[base]runpytest} {envpython} \
+    bash {[base]runpytest} \
          --durations=5 \
          {[base]covtargets} \
          --cov-report=html:htmlcov-py38 \
@@ -138,7 +137,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/runblack.sh {envpython} --check --diff .
+    bash {toxinidir}/.travis/runblack.sh --check --diff .
 
 [testenv:pylint]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
@@ -155,7 +154,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/runpylint.sh {envpython} --errors-only {posargs}
+    bash {toxinidir}/.travis/runpylint.sh --errors-only {posargs}
 
 [testenv:flake8]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:2.7}
@@ -166,7 +165,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/runflake8.sh {envpython} --exclude=.venv,.tox --statistics {posargs} .
+    bash {toxinidir}/.travis/runflake8.sh --exclude=.venv,.tox --statistics {posargs} .
 
 [testenv:yamllint]
 deps = yamllint
@@ -183,7 +182,7 @@ changedir = {[base]changedir}
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/runcoveralls.sh {envpython} {posargs}
+    bash {toxinidir}/.travis/runcoveralls.sh {posargs}
 
 [molecule_common]
 deps =
@@ -201,10 +200,8 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
-         molecule --version
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
-         ansible --version
+    bash {[molecule_common]runsyspycmd} molecule --version
+    bash {[molecule_common]runsyspycmd} ansible --version
 
 [testenv:molecule_lint]
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:molecule}
@@ -213,7 +210,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+    bash {[molecule_common]runsyspycmd} \
          molecule lint -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule_syntax]
@@ -223,7 +220,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+    bash {[molecule_common]runsyspycmd} \
          molecule syntax -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule_test]
@@ -233,7 +230,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {[molecule_common]runsyspycmd} {envpython} {[base]system_python} \
+    bash {[molecule_common]runsyspycmd} \
          molecule test -s {env:LSR_MSCENARIO:default} {posargs}
 
 [testenv:molecule]
@@ -256,7 +253,7 @@ passenv = *
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/custom.sh {envpython} {[base]system_python}
+    bash {toxinidir}/.travis/custom.sh
 
 [pytest]
 addopts = -rxs


### PR DESCRIPTION
Inside of venvs, just use the `python` command directly - the venv
should have configured `PATH` etc. to use the correct python and
environment.  Use `command -p python` to get the system python.