### PR TITLE
Several code cleanup issues for .travis/tox/tests code

### DIFF
--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -37,7 +37,7 @@
 #   * .travis/runflake8.sh:
 #
 #       - RUN_FLAKE8_DISABLED
-#       - RUN_FLAKE8_IGNORE
+#       - RUN_FLAKE8_EXTRA_ARGS
 #
 #   * .travis/runsyspycmd.sh:
 #

--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -26,6 +26,7 @@
 #       - RUN_PYLINT_INCLUDE
 #       - RUN_PYLINT_EXCLUDE
 #       - RUN_PYLINT_DISABLED
+#       - RUN_PYLINT_SETUP_MODULE_UTILS
 #
 #   * .travis/runblack.sh:
 #
@@ -42,9 +43,7 @@
 #   * .travis/runsyspycmd.sh:
 #
 #       - function lsr_runsyspycmd_hook
-
-# if your script needs to setup module_utils so that your
-# module_utils/ code can be resolved by the default
-# pythonpath resolver, an IDE, etc. then call
-# lsr_setup_module_utils
-# here
+#
+#   * .travis/runpytest.sh:
+#
+#       - RUN_PYTEST_SETUP_MODULE_UTILS

--- a/.travis/runcoveralls.sh
+++ b/.travis/runcoveralls.sh
@@ -10,12 +10,12 @@
 # Environment variables:
 #
 #   LSR_PUBLISH_COVERAGE
-#     if the variable is empty or unset, nothing will be published; if the
-#     variable has its value set to 'strict', the reporting is performed in
-#     strict mode, so situations like missing data to be reported are treated
-#     as errors; if the value of this variable is 'debug', coveralls is run in
-#     debug mode (see coveralls debug --help); other values cause that coverage
-#     results will be reported normally
+#     If the variable is unset or empty (the default), no coverage is published.
+#     Other valid values for the variable are:
+#     strict - the reporting is performed in strict mode, so situations
+#              like missing data to be reported are treated as errors
+#     debug  - coveralls is run in debug mode (see coveralls debug --help)
+#     normal - coverage results will be reported normally
 #   LSR_TESTSDIR
 #     a path to directory where tests and tests artifacts are located; if unset
 #     or empty, this variable is set to ${TOPDIR}/tests; this path should
@@ -35,6 +35,13 @@ if [[ -z "${LSR_PUBLISH_COVERAGE}" ]]; then
   lsr_info "${ME}: Publishing coverage report is not enabled. Skipping."
   exit 0
 fi
+
+case "${LSR_PUBLISH_COVERAGE}" in
+    strict) : ;;
+    debug) : ;;
+    normal) : ;;
+    *) lsr_error Error: \"${LSR_PUBLISH_COVERAGE}\" is not a valid option ;;
+esac
 
 LSR_TESTSDIR=${LSR_TESTSDIR:-${TOPDIR}/tests}
 

--- a/.travis/runflake8.sh
+++ b/.travis/runflake8.sh
@@ -10,8 +10,9 @@
 #
 #   RUN_FLAKE8_DISABLED
 #     if set to an arbitrary non-empty value, flake8 will be not executed
-#   RUN_FLAKE8_IGNORE
-#     list of issues to ignore - see flake8 docs
+#
+#   RUN_FLAKE8_EXTRA_ARGS
+#     any extra command line arguments to provide e.g. --ignore=some,errs
 
 set -e
 
@@ -27,6 +28,4 @@ if [[ "${RUN_FLAKE8_DISABLED}" ]]; then
 fi
 
 set -x
-python -m flake8 \
-  ${RUN_FLAKE8_IGNORE:+--ignore} ${RUN_FLAKE8_IGNORE:-} \
-  "$@"
+python -m flake8 ${RUN_FLAKE8_EXTRA_ARGS:-} "$@"

--- a/.travis/runpylint.sh
+++ b/.travis/runpylint.sh
@@ -12,13 +12,24 @@
 
 # The given command line arguments are passed to custom_pylint.py.
 
+# Environment variables:
+#
+#   RUN_PYLINT_SETUP_MODULE_UTILS
+#     if set to an arbitrary non-empty value, the environment will be
+#     configured so that linting of the module_utils/ code will be run
+#     correctly
+
 set -e
 
 ME=$(basename $0)
 SCRIPTDIR=$(readlink -f $(dirname $0))
 
-. ${SCRIPTDIR}/utils.sh
 . ${SCRIPTDIR}/config.sh
+
+if [[ "${RUN_PYLINT_SETUP_MODULE_UTILS}" ]]; then
+  . ${SCRIPTDIR}/utils.sh
+  lsr_setup_module_utils
+fi
 
 set -x
 python ${SCRIPTDIR}/custom_pylint.py "$@"

--- a/.travis/runpytest.sh
+++ b/.travis/runpytest.sh
@@ -10,6 +10,13 @@
 
 # The given command line arguments are passed to pytest.
 
+# Environment variables:
+#
+#   RUN_PYTEST_SETUP_MODULE_UTILS
+#     if set to an arbitrary non-empty value, the environment will be
+#     configured so that tests of the module_utils/ code will be run
+#     correctly
+
 set -e
 
 ME=$(basename $0)
@@ -21,6 +28,10 @@ SCRIPTDIR=$(readlink -f $(dirname $0))
 if [[ ! -d ${TOPDIR}/tests/unit ]]; then
   lsr_info "${ME}: No unit tests found. Skipping."
   exit 0
+fi
+
+if [[ "${RUN_PYTEST_SETUP_MODULE_UTILS}" ]]; then
+  lsr_setup_module_utils
 fi
 
 PYTEST_OPTS=()

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -160,6 +160,7 @@ function lsr_get_system_python() {
 #   $1 - command or full path to venv Python interpreter (default: python)
 #   $2 - command or full path to the system Python interpreter
 #        (default: system python as determined by lsr_get_system_python())
+#
 # Exit with 0 if virtual environment Python version matches the system Python
 # version.
 function lsr_venv_python_matches_system_python() {

--- a/ansible26_requirements.txt
+++ b/ansible26_requirements.txt
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: MIT
-
-# extra requirements for installing ansible 26
-idna<2.8
-PyYAML<5.1
-ansible<2.7

--- a/ansible_pytest_extra_requirements.txt
+++ b/ansible_pytest_extra_requirements.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+
+# ansible and dependencies for all supported platforms
+ansible ; python_version > "2.6"
+ansible<2.7 ; python_version < "2.7"
+idna<2.8 ; python_version < "2.7"
+PyYAML<5.1 ; python_version < "2.7"

--- a/pytest26_extra_requirements.txt
+++ b/pytest26_extra_requirements.txt
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: MIT
-
-# Write extra requirements for running pytest with python2.6 here:
-# NOTE: If your pytests need ansible, use the requirements from
-# ansible26_requirements.txt, either by listing it like this:
-# -ransible26_requirements.txt
-# or by listing the dependencies from that file explicitly

--- a/pytest_extra_requirements.txt
+++ b/pytest_extra_requirements.txt
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 # Write extra requirements for running pytest here:
-# NOTE: for python 2.6 environments, use pytest26_extra_requirements.txt
-# if your pytests need ansible, add ansible here
+# If you need ansible then uncomment the following line:
+#-ransible_pytest_extra_requirements.txt
+# If you need mock then uncomment the following line:
+#mock ; python_version < "3.0"

--- a/tests/setup_module_utils.sh
+++ b/tests/setup_module_utils.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: MIT
 
 set -euo pipefail
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,8 @@ basepython = python3
 deps =
     py{26,27,36,37,38}: pytest-cov
     py{27,36,37,38}: pytest>=3.5.1
-    py{27,36,37,38}: -rpytest_extra_requirements.txt
-    py{26,27}: mock
     py26: pytest
-    py26: -rpytest26_extra_requirements.txt
+    py{26,27,36,37,38}: -rpytest_extra_requirements.txt
 
 [base]
 passenv = *

--- a/tox.ini
+++ b/tox.ini
@@ -162,7 +162,7 @@ deps =
 whitelist_externals =
     {[base]whitelist_externals}
 commands =
-    bash {toxinidir}/.travis/runflake8.sh --exclude=.venv,.tox --statistics {posargs} .
+    bash {toxinidir}/.travis/runflake8.sh {posargs} .
 
 [testenv:yamllint]
 deps = yamllint
@@ -257,6 +257,9 @@ addopts = -rxs
 show_source = true
 max-line-length = 88
 ignore = E402,W503
+exclude = .venv,.tox
+statistics = true
+#verbose = 3
 
 [pylint]
 max-line-length = 88


### PR DESCRIPTION
use versioned dependencies in req files
clarify valid values for LSR_PUBLISH_COVERAGE
do setup_module_utils per-script with env. vars.
move flake8 args to [flake8] section of tox.ini
drop RUN_FLAKE8_IGNORE in favor of RUN_FLAKE8_EXTRA_ARGS
add license header