### PR TITLE
Travis/tox: Run coveralls for all unit tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -268,9 +268,9 @@ max-line-length = 88
 
 [travis]
 python =
-  2.6: py26,custom
-  2.7: py27,flake8,pylint,custom
-  3.5: coveralls,custom
-  3.6: py36,black,yamllint,custom
-  3.7: py37,custom
-  3.8: py38,custom
+  2.6: py26,coveralls,custom
+  2.7: py27,coveralls,flake8,pylint,custom
+  3.5: custom
+  3.6: py36,coveralls,black,yamllint,custom
+  3.7: py37,coveralls,custom
+  3.8: py38,coveralls,custom


### PR DESCRIPTION
Run coveralls after the unit tests to ensure that coverage data is
available

This is a cherry-pick from the network role