### PR TITLE
runpylint.sh: Export RUN_PYLINT_* variables

### DIFF
--- a/.travis/runpylint.sh
+++ b/.travis/runpylint.sh
@@ -31,5 +31,8 @@ if [[ "${RUN_PYLINT_SETUP_MODULE_UTILS}" ]]; then
   lsr_setup_module_utils
 fi
 
+export RUN_PYLINT_DISABLED
+export RUN_PYLINT_EXCLUDE
+export RUN_PYLINT_INCLUDE
 set -x
 python ${SCRIPTDIR}/custom_pylint.py "$@"


### PR DESCRIPTION
Some of the RUN_PYLINT_* variables are evaluated in a python script. To
ensure that they are passed to it, they need to be exported.

Signed-off-by: Till Maas <opensource@till.name>

This is a cherry pick from https://github.com/linux-system-roles/network/pull/197