### PR TITLE
tox: Add travis config for 3.8-dev

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -274,3 +274,4 @@ python =
   3.6: py36,coveralls,black,yamllint,custom
   3.7: py37,coveralls,custom
   3.8: py38,coveralls,custom
+  3.8-dev: py38,coveralls,custom


### PR DESCRIPTION
As reported in https://github.com/tox-dev/tox-travis/issues/147, the
python factor in tox-travis needs to match the Travis python environment
and not the python version. Therefore, add a separate line.

This is a sync from https://github.com/linux-system-roles/network/pull/215