### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/en/articles/about-code-owners
+# Default reviewers for everything
+* @i386x @pcahyna @richm


### PR DESCRIPTION
Use the GitHub codeowners feature to setup default reviewers. They will
be automatically selected for new pull requests.