### PR TITLE
Enable truthy check, allow yes/no/true/false

### DIFF
--- a/.yamllint_defaults.yml
+++ b/.yamllint_defaults.yml
@@ -10,5 +10,7 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
-  truthy: disable
+  truthy:
+    allowed-values: ["yes", "no", "true", "false"]
+    level: error
   document-start: disable


### PR DESCRIPTION
yamllint now lets us configure the allowed boolean values in the truthy check. Let's enable it and allow the values that conform to Ansible doc standards: https://meetbot.fedoraproject.org/ansible-docs/2019-01-08/docs_working_group.2019-01-08-15.31.html