### PR TITLE
use new vars files best practices

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,15 +3,20 @@
 # Put the tasks for your role here.
 
 # An example of how to set distribution and version specific internal variables
-# (defined in vars/ directory):
-- name: Set version specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - "default.yml"
+# (defined in vars/ directory)
+# see https://github.com/oasis-roles/meta_standards#platform-specific-variables
+- name: Set platform/version specific variables
+  include_vars: "{{ __template_vars_file }}"
+  loop:
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - "{{ ansible_facts['distribution'] ~ '_' ~
+          ansible_facts['distribution_major_version'] }}.yml"
+    - "{{ ansible_facts['distribution'] ~ '_' ~
+          ansible_facts['distribution_version'] }}.yml"
+  vars:
+    __template_vars_file: "{{ role_path }}/vars/{{ item }}"
+  when: __template_vars_file is file
 
 # Examples of some tasks:
 - name: Ensure required packages are installed

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: MIT
----
-# Put internal variables here with values for unrecognized distributions.
-
-# Example:
-__template_packages: []
-__template_services: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: MIT
 ---
 # Put the role's internal variables here that are not distribution specific.
+# You can override these by defining the same variable with a different
+# value in a platform/version specific file in vars/
 
 # Examples of non-distribution specific (generic) internal variables:
 __template_foo_config: "foo.conf"
+__template_packages: []
+__template_services: []


### PR DESCRIPTION
For including vars files, use the new best practices from
https://github.com/oasis-roles/meta_standards#platform-specific-variables