### PR TITLE
Make compatible with old Jinja2 (2.7)

### DIFF
--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -10,7 +10,7 @@
         # XXX ugly, self-modifying code - changes the "caller" role on
         # the controller
         dest: "{{ playbook_dir }}/roles/caller/vars/{{ item }}.yml"
-      loop: "{{ varfiles | unique(case_sensitive=true) }}"
+      loop: "{{ varfiles | unique }}"
       # In case the playbook is executed against multiple hosts, use
       # only the first one. Otherwise the hosts would stomp on each
       # other since they are changing files on the controller.


### PR DESCRIPTION
Remove the case_sensitive=true parameter to the unique filter, not supported in older Jinja2. Case sensitivity is not necessary here.

See https://github.com/linux-system-roles/storage/issues/156