### PR TITLE
RHELPLAN-42920 - Collections - script - add tox/travis tests for coll…

### DIFF
--- a/.travis/runcollection.sh
+++ b/.travis/runcollection.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+set -e
+
+#uncomment if you use $ME - otherwise set in utils.sh
+#ME=$(basename "$0")
+SCRIPTDIR=$(readlink -f "$(dirname "$0")")
+
+. "${SCRIPTDIR}/utils.sh"
+. "${SCRIPTDIR}/config.sh"
+
+# Collection commands that are run when `tox -e collection`:
+role=$(basename "${TOPDIR}")
+toxworkdir=${1:-"${TOPDIR}"/.tox}
+STABLE_TAG=${2:-master}
+cd "${toxworkdir}"
+toxworkdir=$(pwd)
+envlist=${3:- "black,flake8,yamllint,py38,shellcheck"}
+automaintenancerepo=https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/
+
+curl -L -o lsr_role2collection.py "${automaintenancerepo}${STABLE_TAG}"/lsr_role2collection.py
+curl -L -o ansible_role_parser.py "${automaintenancerepo}${STABLE_TAG}"/ansible_role_parser.py
+
+python lsr_role2collection.py --src-path "${TOPDIR}/.." --dest-path "${toxworkdir}" --role "${role}" > "${toxworkdir}"/collection.out 2>&1
+
+yamllint="${toxworkdir}"/ansible_collections/fedora/system_roles/.yamllint_defaults.yml
+sed -i -e 's/\( *\)\(document-start: disable\)/\1\2\n\1line-length:\n\1\1level: warning/' "${yamllint}"
+
+cd ansible_collections/fedora/system_roles
+tox -e "${envlist}" 2>&1 | tee "${toxworkdir}"/collection.tox.out || :
+
+rm -rf "${toxworkdir}"/auto-maintenance "${toxworkdir}"/ansible_collections
+cd "${TOPDIR}"
+res=$(grep "^ERROR: .*failed" "${toxworkdir}"/collection.tox.out || :)
+if [ "$res" != "" ]; then
+    lsr_error "${ME}: tox in the converted collection format failed."
+    exit 1
+fi

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -172,6 +172,21 @@ function lsr_venv_python_matches_system_python() {
   lsr_compare_pythons "${1:-python}" -eq "$syspython"
 }
 
+function run_setup_module_utils() {
+  local srcdir
+  srcdir="$1"
+  local destdir
+  destdir="$2"
+  if [ -x "$TOPDIR/tests/setup_module_utils.sh" ]; then
+    bash "$TOPDIR/tests/setup_module_utils.sh" "$srcdir" "$destdir"
+  else
+    setup_module_util=$( find "$TOPDIR"/tests -name "setup_module_utils.sh" | head -n 1 )
+    if [ "$setup_module_util" != "" ]; then
+      bash "$setup_module_util" "$srcdir" "$destdir"
+    fi
+  fi
+}
+
 ##
 # lsr_setup_module_utils [$1] [$2]
 #
@@ -189,7 +204,16 @@ function lsr_setup_module_utils() {
   local destdir
   destdir="${2:-$DEST_MODULE_UTILS_DIR}"
   if [ -n "$srcdir" ] && [ -d "$srcdir" ] && [ -n "$destdir" ] && [ -d "$destdir" ]; then
-    bash "$TOPDIR/tests/setup_module_utils.sh" "$srcdir" "$destdir"
+    run_setup_module_utils "$srcdir" "$destdir"
+  else
+    srcdir="${SRC_COLL_MODULE_UTILS_DIR}"
+    destdir="${DEST_COLL_MODULE_UTILS_DIR}"
+    if [ -n "$destdir" ] && [ -d "$destdir" ]; then
+      if [ -n "$srcdir" ] && [ ! -d "$srcdir" ]; then
+        mkdir -p "$srcdir"
+      fi
+      run_setup_module_utils "$srcdir" "$destdir"
+    fi
   fi
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 envlist =
     black, pylint, flake8, yamllint
     py{26,27,36,37,38}, shellcheck
-    custom
+    collection, custom
 skipsdist = true
 skip_missing_interpreters = true
 
@@ -164,6 +164,16 @@ commands =
     {[testenv:molecule_syntax]commands}
     {[testenv:molecule_test]commands}
 
+[testenv:collection]
+changedir = {toxinidir}
+ansible_python_interpreter = /usr/bin/python3
+deps =
+    ruamel.yaml
+    ansible
+    jmespath
+commands =
+    bash {toxinidir}/.travis/runcollection.sh {toxworkdir} master
+
 [testenv:custom]
 changedir = {toxinidir}
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:custom}
@@ -184,7 +194,7 @@ addopts = -rxs
 [flake8]
 show_source = true
 max-line-length = 88
-ignore = E402,W503
+ignore = E402,W503,E501
 exclude = .venv,.tox
 statistics = true
 #verbose = 3
@@ -200,7 +210,7 @@ max-line-length = 88
 python =
   2.6: py26,coveralls,custom
   2.7: py27,coveralls,flake8,pylint,custom
-  3.6: py36,coveralls,black,yamllint,shellcheck,custom
+  3.6: py36,coveralls,black,yamllint,shellcheck,custom,collection
   3.7: py37,coveralls,custom
   3.8: py38,coveralls,custom
   3.8-dev: py38,coveralls,custom


### PR DESCRIPTION
…ection conversion, verification

Adding collection to envlist in tox.ini and script .travis/collections.sh
that is invoked by "tox -e collection".

Notes:
- collection.sh clone's https://github.com/linux-system-roles/auto-maintenance
  and https://github.com/linux-system-roles/template. Once auto-maintenance pr/13
  is merged, the line cloning the TEMPORARY branch should be replaced.
- collection.sh runs tox with the envlist "yamllint,py38,shellcheck,custom", by
  default. If any other tests to be run, it could added in tox.ini in each role.
  For instance, this command line adds "black,flake8" to the default envlist and
  they pass.
  commands =
    bash {toxinidir}/.travis/collection.sh {toxworkdir} "black,flake8,yamllint,py38,shellcheck,custom"
- I could not find a way to run pylint successfully in the collections format yet.