### PR TITLE
runcollection.sh - stop passing an argument list

### DIFF
--- a/.travis/runcollection.sh
+++ b/.travis/runcollection.sh
@@ -13,12 +13,24 @@ SCRIPTDIR=$(readlink -f "$(dirname "$0")")
 # Collection commands that are run when `tox -e collection`:
 role=$(basename "${TOPDIR}")
 toxworkdir=${1:-"${TOPDIR}"/.tox}
-STABLE_TAG=${2:-master}
+STABLE_TAG=${2:-"master"}
 cd "${toxworkdir}"
 toxworkdir=$(pwd)
-envlist=${3:- "black,flake8,yamllint,py38,shellcheck"}
-automaintenancerepo=https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/
+testlist="yamllint,py38"
+extra="black flake8 shellcheck"
 
+cd "${SCRIPTDIR}"
+for item in ${extra}; do
+    for f in *"${item}"*.sh; do
+        if [ -f "${f}" ]; then
+            testlist+=",${item}"
+            break
+        fi
+    done
+done
+
+cd "${toxworkdir}"
+automaintenancerepo=https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/
 curl -L -o lsr_role2collection.py "${automaintenancerepo}${STABLE_TAG}"/lsr_role2collection.py
 
 python lsr_role2collection.py --src-path "${TOPDIR}/.." --dest-path "${toxworkdir}" --role "${role}" > "${toxworkdir}"/collection.out 2>&1
@@ -27,11 +39,11 @@ yamllint="${toxworkdir}"/ansible_collections/fedora/system_roles/.yamllint_defau
 sed -i -e 's/\( *\)\(document-start: disable\)/\1\2\n\1line-length:\n\1\1level: warning/' "${yamllint}"
 
 cd ansible_collections/fedora/system_roles
-tox -e "${envlist}" 2>&1 | tee "${toxworkdir}"/collection.tox.out || :
+tox -e "${testlist}" 2>&1 | tee "${toxworkdir}"/collection.tox.out || :
 
 rm -rf "${toxworkdir}"/auto-maintenance "${toxworkdir}"/ansible_collections
 cd "${TOPDIR}"
-res=$(grep "^ERROR: .*failed" "${toxworkdir}"/collection.tox.out || :)
+res=$( grep "^ERROR: .*failed" "${toxworkdir}"/collection.tox.out || : )
 if [ "$res" != "" ]; then
     lsr_error "${ME}: tox in the converted collection format failed."
     exit 1


### PR DESCRIPTION
Instead of setting an argument list to runcollection.sh in tox.ini,
it checks the availability in the runcollection.sh script and pass
the generated list to the tox test against the converted collections
format.

See also https://github.com/linux-system-roles/network/pull/304#discussion_r513001651.