### PR TITLE
Remove reference to deprecated ansible containers

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,10 +23,6 @@ galaxy_info:
 
   min_ansible_version: 2.7
 
-  # If this is a Container Enabled role, provide the minimum Ansible Container
-  # version.
-  # min_ansible_container_version:
-
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available, Galaxy
   # will use this branch. During import Galaxy will access files on this


### PR DESCRIPTION
As far as I was able to find, ansible container is deprecated so there is no need to push it into the templates

https://github.com/ansible/ansible-container