### PR TITLE
Unbreak Github Actions based on the work in crypto policies role

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -2,6 +2,7 @@
 name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
+  - push
 env:
   TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@main"
   LSR_ANSIBLES: 'ansible==2.7.* ansible==2.8.* ansible==2.9.*'


### PR DESCRIPTION
 * Remove CentOS 6 build as it seems to be broken
 * Add CentOS 8 image
 * Remove ansible 2.7 as ansible-lint is no longer installable with it
 * Build also on push to generate the build status icons in readme
 * Use Python 3 packages with DNF for CentOS 8

https://github.com/linux-system-roles/crypto_policies/pull/4/