### PR TITLE
remove ansible 2.7 support from molecule

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,7 +5,7 @@ on:  # yamllint disable-line rule:truthy
   - push
 env:
   TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@main"
-  LSR_ANSIBLES: 'ansible==2.7.* ansible==2.8.* ansible==2.9.*'
+  LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: libdbus-1-dev
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -25,8 +25,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     command: /usr/lib/systemd/systemd --system
-    groups:
-      - py3
 provisioner:
   name: ansible
   log: true
@@ -34,10 +32,6 @@ provisioner:
     enabled: false
   playbooks:
     converge: ../../tests/tests_default.yml
-  inventory:
-    group_vars:
-      py3:
-        ansible_python_interpreter: /usr/bin/python3
 scenario:
   name: default
   test_sequence:


### PR DESCRIPTION
ansible 2.7 has been deprecated
https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
We need to remove ansible 2.7 from molecule testing in order to
* make room for ansible 2.10 testing
* move to molecule v3

ansible 2.8 and later support platform-python on el8 and later
so we don't have to handle that case explicitly by setting
ansible_python_interpreter for centos8 in molecule.yml