### PR TITLE
drop molecule v2 for molecule v3; support podman

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,9 +3,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
-lint:
-  enabled: false
+  name: ${LSR_MOLECULE_DRIVER:-docker}
 platforms:
   - name: centos-6
     image: registry.centos.org/centos:6
@@ -28,8 +26,6 @@ platforms:
 provisioner:
   name: ansible
   log: true
-  lint:
-    enabled: false
   playbooks:
     converge: ../../tests/tests_default.yml
 scenario:


### PR DESCRIPTION
This drops support for molecule v2.  It requires the linter sections.
In molecule v3, since we don't use the molecule linters, we have to
remove those sections.  This means you cannot use the molecule.yml
with molecule v2 anymore - you must use molecule v3.  This means you
need to update tox-lsr to version 2.0.0 or later:
https://github.com/linux-system-roles/tox-lsr/releases/tag/2.0.0

This also adds support for podman.  You can use
`LSR_MOLECULE_DRIVER=podman tox -e molecule`
to use `podman` instead of `docker`.