### PR TITLE
Fix unset file permissions within the copy module

### DIFF
--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,6 +1,5 @@
 - hosts: all
   tasks:
-
     - name: create var file in caller that can override the one in called role
       delegate_to: localhost
       copy:
@@ -11,6 +10,7 @@
         # XXX ugly, self-modifying code - changes the "caller" role on
         # the controller
         dest: "{{ playbook_dir }}/roles/caller/vars/{{ item }}.yml"
+        mode: preserve
       loop: "{{ varfiles | unique }}"
       # In case the playbook is executed against multiple hosts, use
       # only the first one. Otherwise the hosts would stomp on each

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,5 +1,6 @@
 - hosts: all
   tasks:
+
     - name: create var file in caller that can override the one in called role
       delegate_to: localhost
       copy:


### PR DESCRIPTION
By default, tox fails the tests/tests_include_vars_from_parent.yml file because the copy module does not use `mode: preserve`.