### PR TITLE
Removed unnecessary quotings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,5 +4,5 @@
 # This file also serves as a documentation for such a variables.
 
 # Examples of role input variables:
-template_foo: "foo"
-template_bar: "bar"
+template_foo: foo
+template_bar: bar

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,7 +5,7 @@
 # value in a platform/version specific file in vars/
 
 # Examples of non-distribution specific (generic) internal variables:
-__template_foo_config: "foo.conf"
+__template_foo_config: foo.conf
 __template_packages: []
 __template_services: []
 # ansible_facts required by the role


### PR DESCRIPTION
I've removed the unnecessary quotings I could find in the template to match the [automation-good-practises](https://github.com/redhat-cop/automation-good-practices/blob/main/coding_style/README.adoc) that @richm cited in #81.

This PR should resolve #81.

Signed-off-by: Joerg Kastning <joerg.kastning@uni-bielefeld.de>