### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/foo.conf.j2
+++ b/templates/foo.conf.j2
@@ -3,6 +3,7 @@
 # Example of a template of configuration file
 #
 {{ ansible_managed | comment }}
+{{ "system_role:rolename" | comment(prefix="", postfix="") }}
 [foo]
 foo = {{ template_foo }}
 bar = {{ template_bar }}


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:rolename
```
ote: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.