### PR TITLE
test: ensure the test works with ANSIBLE_GATHERING=explicit

### DIFF
--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,6 +1,7 @@
 ---
 - name: Test role variable override
   hosts: all
+  gather_facts: true
   tasks:
     - name: Create var file in caller that can override the one in called role
       delegate_to: localhost


### PR DESCRIPTION
Use `gather_facts: true` to ensure the test has the facts it
needs when testing with `ANSIBLE_GATHERING=explicit`
