### PR TITLE
fix: facts being gathered unnecessarily

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,9 +1,9 @@
 ---
 - name: Ensure ansible_facts used by role
   setup:
-    gather_subset: min
-  when: not ansible_facts.keys() | list |
-    intersect(__template_required_facts) == __template_required_facts
+    gather_subset: "{{ __template_required_facts_subsets }}"
+  when: __template_required_facts |
+    difference(ansible_facts.keys() | list) | length > 0
 
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,3 +14,8 @@ __template_required_facts:
   - distribution_major_version
   - distribution_version
   - os_family
+# the subsets of ansible_facts that need to be gathered in case any of the
+# facts in required_facts is missing; see the documentation of
+# the 'gather_subset' parameter of the 'setup' module
+__template_required_facts_subsets: "{{ ['!all', '!min'] +
+  __template_required_facts }}"


### PR DESCRIPTION
Cause: The comparison of the present facts with the required facts is
being done on unsorted lists.

Consequence: The comparison may fail if the only difference is the
order.  Facts are gathered unnecessarily.

Fix: Use `difference` which works no matter what the order is.  Ensure
that the fact gathering subsets used are the absolute minimum required.

Result: The role gathers only the facts it requires, and does
not unnecessarily gather facts.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
