### PR TITLE
ci: update github action checkout to v4; ensure order of badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
Use v4 github action checkout
Ensure dependabot git commit message conforms to our
project
Ensure order of common badges (badges common to all roles)
Role extra badges are appended to the end of the list of common
badges

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
