### PR TITLE
feat: support for ostree systems

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,3 +22,5 @@ exclude_paths:
   - examples/roles/
 mock_roles:
   - linux-system-roles.template
+mock_modules:
+  - ansible.utils.update_fact

--- a/.ostree/README.md
+++ b/.ostree/README.md
@@ -1,0 +1,3 @@
+*NOTE*: The `*.txt` files are used by `get_ostree_data.sh` to create the lists
+of packages, and to find other system roles used by this role.  DO NOT use them
+directly.

--- a/.ostree/get_ostree_data.sh
+++ b/.ostree/get_ostree_data.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -euo pipefail
+
+role_collection_dir="${ROLE_COLLECTION_DIR:-fedora/linux_system_roles}"
+ostree_dir="${OSTREE_DIR:-"$(dirname "$(realpath "$0")")"}"
+
+if [ -z "${4:-}" ] || [ "${1:-}" = help ] || [ "${1:-}" = -h ]; then
+    cat <<EOF
+Usage: $0 packages [runtime|testing] DISTRO-MAJOR[.MINOR] [json|yaml|raw|toml]
+The script will use the packages and roles files in $ostree_dir to
+construct the list of packages needed to build the ostree image.  The script
+will output the list of packages in the given format
+- json is a JSON list like ["pkg1","pkg2",....,"pkgN"]
+- yaml is the YAML list format
+- raw is the list of packages, one per line
+- toml is a list of [[packages]] elements as in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line
+The DISTRO-MAJOR.MINOR is the same format used by Ansible for distribution e.g. CentOS-8, RedHat-8.9, etc.
+EOF
+    exit 1
+fi
+category="$1"
+pkgtype="$2"
+distro_ver="$3"
+format="$4"
+pkgtypes=("$pkgtype")
+if [ "$pkgtype" = testing ]; then
+    pkgtypes+=(runtime)
+fi
+
+get_rolepath() {
+    local ostree_dir role rolesdir roles_parent_dir
+    ostree_dir="$1"
+    role="$2"
+    roles_parent_dir="$(dirname "$(dirname "$ostree_dir")")"
+    rolesdir="$roles_parent_dir/$role/.ostree"
+    # assumes collection format
+    if [ -d "$rolesdir" ]; then
+        echo "$rolesdir"
+        return 0
+    fi
+    # assumes legacy role format like linux-system-roles.$role/
+    for rolesdir in "$roles_parent_dir"/*-system-roles."$role"/.ostree; do
+        if [ -d "$rolesdir" ]; then
+          echo "$rolesdir"
+          return 0
+        fi
+    done
+    # look elsewhere
+    if [ -n "${ANSIBLE_COLLECTIONS_PATHS:-}" ]; then
+        for pth in ${ANSIBLE_COLLECTIONS_PATHS//:/ }; do
+            rolesdir="$pth/ansible_collections/$role_collection_dir/roles/$role/.ostree"
+            if [ -d "$rolesdir" ]; then
+                echo "$rolesdir"
+                return 0
+            fi
+        done
+    fi
+    return 1
+}
+
+get_packages() {
+    local ostree_dir pkgtype pkgfile rolefile
+    ostree_dir="$1"
+    for pkgtype in "${pkgtypes[@]}"; do
+        for suff in "" "-$distro" "-${distro}-${major_ver}" "-${distro}-${ver}"; do
+            pkgfile="$ostree_dir/packages-${pkgtype}${suff}.txt"
+            if [ -f "$pkgfile" ]; then
+                cat "$pkgfile"
+            fi
+        done
+        rolefile="$ostree_dir/roles-${pkgtype}.txt"
+        if [ -f "$rolefile" ]; then
+            local roles role rolepath
+            roles="$(cat "$rolefile")"
+            for role in $roles; do
+                rolepath="$(get_rolepath "$ostree_dir" "$role")"
+                get_packages "$rolepath"
+            done
+        fi
+    done | sort -u
+}
+
+format_packages_json() {
+    local comma pkgs pkg
+    comma=""
+    pkgs="["
+    while read -r pkg; do
+        pkgs="${pkgs}${comma}\"${pkg}\""
+        comma=,
+    done
+    pkgs="${pkgs}]"
+    echo "$pkgs"
+}
+
+format_packages_raw() {
+    cat
+}
+
+format_packages_yaml() {
+    while read -r pkg; do
+        echo "- $pkg"
+    done
+}
+
+format_packages_toml() {
+    while read -r pkg; do
+        echo "[[packages]]"
+        echo "name = \"$pkg\""
+        echo "version = \"*\""
+    done
+}
+
+distro="${distro_ver%%-*}"
+ver="${distro_ver##*-}"
+if [[ "$ver" =~ ^([0-9]*) ]]; then
+    major_ver="${BASH_REMATCH[1]}"
+else
+    echo ERROR: cannot parse major version number from version "$ver"
+    exit 1
+fi
+
+"get_$category" "$ostree_dir" | "format_${category}_$format"

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -1,0 +1,1 @@
+roles/template/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -1,0 +1,1 @@
+roles/template/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,0 +1,1 @@
+roles/template/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -1,0 +1,1 @@
+roles/template/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,0 +1,1 @@
+roles/template/.ostree/get_ostree_data.sh shebang!skip

--- a/README-ostree.md
+++ b/README-ostree.md
@@ -1,0 +1,66 @@
+# rpm-ostree
+
+The role supports running on [rpm-ostree](https://coreos.github.io/rpm-ostree/)
+systems. The primary issue is that the `/usr` filesystem is read-only, and the
+role cannot install packages. Instead, it will just verify that the necessary
+packages and any other `/usr` files are pre-installed. The role will change the
+package manager to one that is compatible with `rpm-ostree` systems.
+
+## Building
+
+To build an ostree image for a particular operating system distribution and
+version, use the script `.ostree/get_ostree_data.sh` to get the list of
+packages. If the role uses other system roles, then the script will include the
+packages for the other roles in the list it outputs.  The list of packages will
+be sorted in alphanumeric order.
+
+Usage:
+
+```bash
+.ostree/get_ostree_data.sh packages runtime DISTRO-VERSION FORMAT
+```
+
+`DISTRO-VERSION` is in the format that Ansible uses for `ansible_distribution`
+and `ansible_distribution_version` - for example, `Fedora-38`, `CentOS-8`,
+`RedHat-9.4`
+
+`FORMAT` is one of `toml`, `json`, `yaml`, `raw`
+
+* `toml` - each package in a TOML `[[packages]]` element
+
+```toml
+[[packages]]
+name = "package-a"
+version = "*"
+[[packages]]
+name = "package-b"
+version = "*"
+...
+```
+
+* `yaml` - a YAML list of packages
+
+```yaml
+- package-a
+- package-b
+...
+```
+
+* `json` - a JSON list of packages
+
+```json
+["package-a","package-b",...]
+```
+
+* `raw` - a plain text list of packages, one per line
+
+```bash
+package-a
+package-b
+...
+```
+
+What format you choose depends on which image builder you are using.  For
+example, if you are using something based on
+[osbuild-composer](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line),
+you will probably want to use the `toml` output format.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ distinction between *control node* requirements (like collections) and
 
 ### Collection requirements
 
-For instance, if the role depends on some collections and
-has a `meta/collection-requirements.yml` file for installing those
-dependencies, it should be mentioned here that the user should run
+For instance, if the role depends on some collections and has a
+`meta/collection-requirements.yml` file for installing those dependencies, and
+in order to manage `rpm-ostree` systems, it should be mentioned here that the
+ user should run
 
 ```bash
 ansible-galaxy collection install -vv -r meta/collection-requirements.yml
@@ -89,6 +90,10 @@ passed in as parameters) is always nice for users too:
 
 More examples can be provided in the [`examples/`](examples) directory. These
 can be useful, especially for documentation.
+
+## rpm-ostree
+
+See README-ostree.md
 
 ## License
 

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+---
+collections:
+  - ansible.posix
+  - ansible.utils

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -5,6 +5,24 @@
   when: __template_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
+- name: Ensure correct package manager for ostree systems
+  vars:
+    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
+    ostree_booted_file: /run/ostree-booted
+  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: "{{ ostree_booted_file }}"
+      register: __ostree_booted_stat
+
+    - name: Set package manager to use for ostree
+      ansible.utils.update_fact:
+        updates:
+          - path: ansible_facts.pkg_mgr
+            value: "{{ ostree_pkg_mgr }}"
+      when: __ostree_booted_stat.stat.exists
+
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"
   loop:


### PR DESCRIPTION
Feature: Allow running and testing the role with ostree managed nodes.

Reason: We have users who want to use the role to manage ostree
systems.

Result: Users can use the role to manage ostree managed nodes.
Signed-off-by: Rich Megginson <rmeggins@redhat.com>
