### PR TITLE
fix: Avoid setting ansible_managed variable

### DIFF
--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"


### PR DESCRIPTION
Cause: The test used a temporary variable `ansible_managed`, but that is a "magic" string constant. Ansible 2.19 does not permit assigning to it any more.

Consequence: Tests failed with Ansible 2.19.

Fix: Rename the variable.

---

This should fix the current  [Ansible 2.19 failure](https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/tf_template-121_Fedora-42-2.19_20250614-013704/artifacts/tests_default-ANSIBLE-2.19-test_playbooks_parallel-FAIL.log)

## Summary by Sourcery

Bug Fixes:
- Rename test variable `ansible_managed` to `__ansible_managed` to avoid setting a magic Ansible variable and fix test failures on Ansible 2.19.