### PR TITLE
feat: Add argument spec validation to template role

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ on the *control node* before using the role.
 
 ## Role Variables
 
+Validation is enforced by `meta/argument_specs.yml`.
+
 A description of all input variables (i.e. variables that are defined in
 `defaults/main.yml`) for the role should go here as these form an API of the
 role.  Each variable should have its own section e.g.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,51 @@ role.  Each variable should have its own section e.g.
 
 ### template_foo
 
-This variable is required.  It is a string that lists the foo of the role.
-There is no default value.
+A string variable for the foo setting.
+The default value is `"foo"`.
 
 ### template_bar
 
-This variable is optional.  It is a boolean that tells the role to disable bar.
+A boolean variable that enables or disables the bar feature.
 The default value is `true`.
+
+### template_baz
+
+An integer variable for a numeric setting.
+The default value is `0`.
+
+### template_config_path
+
+Filesystem path to the configuration file.
+The default value is `"/etc/template.conf"`.
+
+### template_state
+
+Desired state of the template subsystem.  Must be one of `enabled`
+or `disabled`.  The default value is `"enabled"`.
+
+### template_packages
+
+A list of package names (strings).
+The default value is `[]`.
+
+### template_raw_value
+
+A variable that accepts values of different types (e.g. a string or a list).
+The default value is `""`.
+
+### template_services
+
+A list of service configurations.  Each entry is a dictionary with the
+following keys:
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | str | yes | Name of the service. |
+| `type` | str | no | Type of the service.  One of `simple`, `forking`, `oneshot`. |
+| `enabled` | bool | no | Whether the service should be enabled at boot. |
+
+The default value is `[]`.
 
 Variables that are not intended as input, like variables defined in
 `vars/main.yml`, variables that are read from other roles and/or the global
@@ -57,6 +95,21 @@ Example of setting the variables:
 ```yaml
 template_foo: "oof"
 template_bar: false
+template_baz: 42
+template_config_path: /etc/myapp/config.yml
+template_state: disabled
+template_packages:
+  - vim
+  - tmux
+template_raw_value:
+  - first
+  - second
+template_services:
+  - name: httpd
+    type: forking
+    enabled: true
+  - name: my-worker
+    type: simple
 ```
 
 ## Variables Exported by the Role
@@ -86,6 +139,12 @@ passed in as parameters) is always nice for users too:
   vars:
     template_foo: "foo foo!"
     template_bar: false
+    template_baz: 42
+    template_state: disabled
+    template_services:
+      - name: httpd
+        type: forking
+        enabled: true
   roles:
     - linux-system-roles.template
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,9 @@
 # Examples of role input variables:
 template_foo: foo
 template_bar: true
+template_baz: 0
+template_config_path: /etc/template.conf
+template_state: enabled
+template_packages: []
+template_raw_value: ""
+template_services: []

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -6,5 +6,71 @@ argument_specs:
     options:
       template_foo:
         type: str
+        description: >-
+          A string variable for the foo setting.
+
       template_bar:
         type: bool
+        description: >-
+          A boolean variable that enables or disables the bar feature.
+
+      template_baz:
+        type: int
+        description: >-
+          An integer variable for a numeric setting.
+
+      template_config_path:
+        type: path
+        description: >-
+          Filesystem path to the configuration file.
+
+      template_state:
+        type: str
+        choices:
+          - enabled
+          - disabled
+        description: >-
+          Desired state of the template subsystem.  Use choices to
+          restrict a string variable to a fixed set of allowed values.
+
+      template_packages:
+        type: list
+        elements: str
+        description: >-
+          A list of package names.  Use elements to declare the type
+          of each item in the list.
+
+      template_raw_value:
+        type: raw
+        description: >-
+          A variable that accepts values of different types.  Use raw
+          when the variable can be either a string or a list, for
+          example.
+
+      template_services:
+        type: list
+        elements: dict
+        description: >-
+          A list of service configurations.  Each entry is a dictionary
+          with its own set of options.  Use this pattern when the role
+          takes a list of structured items.
+        options:
+          name:
+            type: str
+            required: true
+            description: >-
+              Name of the service.  Mark a sub-option as required when
+              it must always be provided.
+          type:
+            type: str
+            choices:
+              - simple
+              - forking
+              - oneshot
+            description: >-
+              Type of the service.  Choices work inside nested options
+              the same way as at the top level.
+          enabled:
+            type: bool
+            description: >-
+              Whether the service should be enabled at boot.

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+argument_specs:
+  main:
+    short_description: Basic template for Linux system roles
+    options:
+      template_foo:
+        type: str
+      template_bar:
+        type: bool


### PR DESCRIPTION
Enhancement: Added argument spec validation to template role.

Reason: Because it is a good addition to the linux-system-roles project.

Result: Successfully added it. Local tmt test also works.

Issue Tracker Tickets (Jira or BZ if any): https://github.com/linux-system-roles/postfix/issues/206 https://redhat.atlassian.net/browse/RHELMISC-16008


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional template-related role inputs (including state, config path, packages, raw value, and service entries).
  * Expanded role variable validation to cover the full set of template inputs, including typed service details.
* **Documentation**
  * Expanded and corrected “Role Variables” guidance, including updated example playbook settings for the newly supported template inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->